### PR TITLE
Generalize ZarrPixelsService.getUri to support additional entityType/entityId

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
@@ -187,14 +187,29 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
         return Paths.get(ngffDir);
     }
 
-
     /**
-     * Retrieve {@link Mask} or {@link Image} URI.
+     * Retrieve {@link Mask} or {@link Image} URI stored under {@link ExternalInfo}.
      * @param object loaded {@link Mask} or {@link Image} to check for a URI
-     * @return URI or <code>null</code> if the object does not contain a URI
-     * in its {@link ExternalInfo}.
+     * @return the value of {@link ExternalInfo.lsid}, <code>null</code> if the object
+     * does not have an {@link ExternalInfo} with a valid {@link ExternalInfo.lsid} atttribute
+     * or if {@link ExternalInfo.entityType} is not equal to {@link NGFF_ENTITY_TYPE} or if
+     * {@link ExternalInfo.entityId} is not equal to {@link NGFF_ENTITY_ID}.
      */
     public String getUri(IObject object) {
+        return getUri(object, NGFF_ENTITY_TYPE, NGFF_ENTITY_ID);
+    }
+
+    /**
+     * Retrieve {@link Mask} or {@link Image} URI stored under {@link ExternalInfo}
+     * @param object loaded {@link Mask} or {@link Image} to check for a URI
+     * @param targetEntityType expected entityType in the object {@link ExternalInfo}
+     * @param targetEntityId expected entityType in the object {@link ExternalInfo}
+     * @return the value of {@link ExternalInfo.lsid}, <code>null</code> if the object
+     * does not have an {@link ExternalInfo} with a valid {@link ExternalInfo.lsid} atttribute
+     * or if {@link ExternalInfo.entityType} is not equal to <code>targetEntityType</code> or if
+     * {@link ExternalInfo.entityId} is not equal to <code>targetEntityId</code> .
+     */
+    public String getUri(IObject object, String targetEntityType, Long targetEntityId) {
         ExternalInfo externalInfo = object.getDetails().getExternalInfo();
         if (externalInfo == null) {
             log.debug(
@@ -210,7 +225,7 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
                 object.getClass().getSimpleName(), object.getId());
             return null;
         }
-        if (!entityType.equals(NGFF_ENTITY_TYPE)) {
+        if (!entityType.equals(targetEntityType)) {
             log.debug(
                 "{}:{} unsupported ExternalInfo entityType {}",
                 object.getClass().getSimpleName(), object.getId(), entityType);
@@ -224,7 +239,7 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
                 object.getClass().getSimpleName(), object.getId());
             return null;
         }
-        if (!entityId.equals(NGFF_ENTITY_ID)) {
+        if (!entityId.equals(targetEntityId)) {
             log.debug(
                 "{}:{} unsupported ExternalInfo entityId {}",
                 object.getClass().getSimpleName(), object.getId(), entityId);

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package com.glencoesoftware.omero.ms.core;
+package com.glencoesoftware.omero.zarr;
 
 import java.awt.Dimension;
 import java.io.File;

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelsServiceTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelsServiceTest.java
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-package com.glencoesoftware.omero.ms.core;
+package com.glencoesoftware.omero.zarr;
 
 import java.io.IOException;
 import java.io.File;
@@ -43,7 +43,7 @@ import static omero.rtypes.rdouble;
 import static omero.rtypes.rlong;
 import static omero.rtypes.rstring;
 
-public class PixelsServiceTest {
+public class ZarrPixelsServiceTest {
 
   private ZarrPixelsService pixelsService;
   private String uuid = UUID.randomUUID().toString();

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelsServiceTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelsServiceTest.java
@@ -51,8 +51,9 @@ public class ZarrPixelsServiceTest {
   private String labelUri = imageUri + "/0/labels/" + uuid;
   private Image image;
   private Mask mask;
+  private ome.model.IObject object;
   private String ENTITY_TYPE = "com.glencoesoftware.ngff:multiscales";
-  private int ENTITY_ID = 3;
+  private long ENTITY_ID = 3;
 
   @Before
   public void setUp() throws IOException {
@@ -66,7 +67,7 @@ public class ZarrPixelsServiceTest {
       image = new ImageI();
   }
 
-  private void addExternalInfo(IObject object, Integer entityId, String entityType, String lsid, String uuid) {
+  private void addExternalInfo(IObject object, Long entityId, String entityType, String lsid, String uuid) {
         ExternalInfo externalInfo = new ExternalInfoI();
         externalInfo.setEntityId(rlong(entityId));
         externalInfo.setEntityType(rstring(entityType));
@@ -82,51 +83,80 @@ public class ZarrPixelsServiceTest {
   @Test
   public void testDefault() throws ApiUsageException, IOException {
       addExternalInfo(mask, ENTITY_ID, ENTITY_TYPE, labelUri, uuid);
-      Assert.assertEquals(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)), labelUri);
+      object = (ome.model.roi.Mask) new IceMapper().reverse(mask);
+      Assert.assertEquals(pixelsService.getUri(object), labelUri);
+      Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID), labelUri);
 
       addExternalInfo(image, ENTITY_ID, ENTITY_TYPE, imageUri, uuid);
-      Assert.assertEquals(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)), imageUri);
+      object = (ome.model.core.Image) new IceMapper().reverse(image);
+      Assert.assertEquals(pixelsService.getUri(object), imageUri);
+      Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID), imageUri);
   }
 
   @Test
   public void testGetUriNoExternalInfo() throws ApiUsageException, IOException {
-      Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
-      Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+      object = (ome.model.roi.Mask) new IceMapper().reverse(mask);
+      Assert.assertNull(pixelsService.getUri(object));
+      Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
+
+      object = (ome.model.core.Image) new IceMapper().reverse(image);
+      Assert.assertNull(pixelsService.getUri(object));
+      Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
   }
 
   @Test
   public void testGetUriNoUuid() throws ApiUsageException, IOException {
       addExternalInfo(mask, ENTITY_ID, ENTITY_TYPE, labelUri, null);
-      Assert.assertEquals(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)), labelUri);
+      object = (ome.model.roi.Mask) new IceMapper().reverse(mask);
+      Assert.assertEquals(pixelsService.getUri(object), labelUri);
+      Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID), labelUri);
 
       addExternalInfo(image, ENTITY_ID, ENTITY_TYPE, imageUri, null);
-      Assert.assertEquals(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)), imageUri);
+      object = (ome.model.core.Image) new IceMapper().reverse(image);
+      Assert.assertEquals(pixelsService.getUri(object), imageUri);
+      Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID), imageUri);
   }
 
   @Test
   public void testGetUriNoLsid() throws ApiUsageException, IOException {
       addExternalInfo(mask, ENTITY_ID, ENTITY_TYPE, null, uuid);
-      Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
+      object = (ome.model.roi.Mask) new IceMapper().reverse(mask);
+      Assert.assertNull(pixelsService.getUri(object));
+      Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
 
       addExternalInfo(image, ENTITY_ID, ENTITY_TYPE, null, uuid);
-      Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+      object = (ome.model.core.Image) new IceMapper().reverse(image);
+      Assert.assertNull(pixelsService.getUri(object));
+      Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
   }
 
   @Test
   public void testGetUriWrongEntityType() throws ApiUsageException, IOException {
       addExternalInfo(mask, ENTITY_ID, "multiscales", labelUri, uuid);
-      Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
+      object = (ome.model.roi.Mask) new IceMapper().reverse(mask);
+      Assert.assertNull(pixelsService.getUri(object));
+      Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
+      Assert.assertEquals(pixelsService.getUri(object, "multiscales", ENTITY_ID), labelUri);
 
       addExternalInfo(image, ENTITY_ID, "multiscales", imageUri, uuid);
-      Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+      object = (ome.model.core.Image) new IceMapper().reverse(image);
+      Assert.assertNull(pixelsService.getUri(object));
+      Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
+      Assert.assertEquals(pixelsService.getUri(object, "multiscales", ENTITY_ID), imageUri);
   }
 
   @Test
   public void testGetUriWrongEntityId() throws ApiUsageException, IOException {
-    addExternalInfo(mask, 1, ENTITY_TYPE, labelUri, uuid);
-    Assert.assertNull(pixelsService.getUri((ome.model.roi.Mask) new IceMapper().reverse(mask)));
+    addExternalInfo(mask, 1L, ENTITY_TYPE, labelUri, uuid);
+    object = (ome.model.roi.Mask) new IceMapper().reverse(mask);
+    Assert.assertNull(pixelsService.getUri(object));
+    Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
+    Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, 1L), labelUri);
 
-    addExternalInfo(image, 1, ENTITY_TYPE, imageUri, uuid);
-    Assert.assertNull(pixelsService.getUri((ome.model.core.Image) new IceMapper().reverse(image)));
+    addExternalInfo(image, 1L, ENTITY_TYPE, imageUri, uuid);
+    object = (ome.model.core.Image) new IceMapper().reverse(image);
+    Assert.assertNull(pixelsService.getUri(object));
+    Assert.assertNull(pixelsService.getUri(object, ENTITY_TYPE, ENTITY_ID));
+    Assert.assertEquals(pixelsService.getUri(object, ENTITY_TYPE, 1L), imageUri);
   }
 }


### PR DESCRIPTION
This change adds a new signature `ZarrPixelsService.getUri(IObject, String, String)` allowing to specify custom entityType/entityId values to check in the object external info. The semantics of `ZarrPixelsService.getUri(IObject)` is unchanged and still checks `NGFF_ENTITY_TYPE` and `NGFF_ENTITY_ID`. The unit tests are adjusted to test both signatures.

Noticed during the review of https://github.com/glencoesoftware/omero-ms-image-region/pull/142, 141fb5013789f7172d53b406161f7d7d6f05f23a updates the remaining references to the previous package and use `com.glencoesoftware.omero.zarr` consistently. There are no functional changes, this is primarily tidy-up
