### PR TITLE
Add null check for image.getFormat()

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
@@ -325,7 +325,7 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
             String uri = getUri(image);
             if (uri == null) {
                 // Quick exit if we think we're OME-NGFF but there is no URI
-                if ("OMEXML".equals(image.getFormat().getValue())) {
+                if (image.getFormat() != null && "OMEXML".equals(image.getFormat().getValue())) {
                     throw new LockTimeout("Import in progress.", 15*1000, 0);
                 }
                 log.debug("No OME-NGFF root");


### PR DESCRIPTION
Under some conditions, an Image might have no associated format. This will be the case for ROMIO pixel buffer e.g. created by scripts or OMERO pyramid pixel buffer  created by the PixelService for large images without resolutions.

To test this PR, use an OMERO.server with the https://github.com/glencoesoftware/omero-zarr-pixel-buffer extension and create a ROMIO image e.g. using the `Images from ROIs` script.

Without this PR a call to `RenderingSettings.resetDefaults` will cause a NPE of type

```
java.lang.NullPointerException: Cannot invoke "ome.model.enums.Format.getValue()" because the return value of "ome.model.core.Image.getFormat()" is null
	at com.glencoesoftware.omero.zarr.ZarrPixelsService.createOmeNgffPixelBuffer(ZarrPixelsService.java:328)
	at com.glencoesoftware.omero.zarr.ZarrPixelsService.getPixelBuffer(ZarrPixelsService.java:369)
	at ome.logic.RenderingSettingsImpl.resetDefaults(RenderingSettingsImpl.java:520)
	at ome.logic.RenderingSettingsImpl.resetDefaults(RenderingSettingsImpl.java:1439)
```

and the image will end up in a broken state.

With this PR, the `PixelsService.getPixelBuffer` should return a `RomioPixelBuffer` as expected and the server logic should complete the creation of a rendering definition and thumbnail