### PR TITLE
Fix and expand range checks when performing tile retrieval

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
@@ -137,6 +137,8 @@ public class ZarrPixelBuffer implements PixelBuffer {
                     int w = key.get(6);
                     int h = key.get(7);
                     int[] shape = new int[] { 1, 1, 1, h, w };
+                    // Check planar read size (sizeX and sizeY only)
+                    checkReadSize(Arrays.copyOfRange(shape, 3, 5));
                     byte[] innerBuffer =
                             new byte[(int) length(shape) * getByteWidth()];
                     setResolutionLevel(resolutionLevel);

--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
@@ -326,6 +326,7 @@ public class ZarrPixelBuffer implements PixelBuffer {
      * Implemented as specified by {@link PixelBuffer} I/F.
      * @see PixelBuffer#checkBounds(Integer, Integer, Integer, Integer, Integer)
      */
+    @Override
     public void checkBounds(Integer x, Integer y, Integer z, Integer c,
             Integer t)
             throws DimensionsOutOfBoundsException {

--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
@@ -326,21 +326,21 @@ public class ZarrPixelBuffer implements PixelBuffer {
             throws DimensionsOutOfBoundsException {
         if (x != null && (x > getSizeX() - 1 || x < 0)) {
             throw new DimensionsOutOfBoundsException("X '" + x
-                    + "' greater than sizeX '" + getSizeX() + "'.");
+                    + "' greater than sizeX '" + getSizeX() + "' or < '0'.");
         }
         if (y != null && (y > getSizeY() - 1 || y < 0)) {
             throw new DimensionsOutOfBoundsException("Y '" + y
-                    + "' greater than sizeY '" + getSizeY() + "'.");
+                    + "' greater than sizeY '" + getSizeY() + "' or < '0'.");
         }
 
         if (z != null && (z > getSizeZ() - 1 || z < 0)) {
             throw new DimensionsOutOfBoundsException("Z '" + z
-                    + "' greater than sizeZ '" + getSizeZ() + "'.");
+                    + "' greater than sizeZ '" + getSizeZ() + "' or < '0'.");
         }
 
         if (c != null && (c > getSizeC() - 1 || c < 0)) {
             throw new DimensionsOutOfBoundsException("C '" + c
-                    + "' greater than sizeC '" + getSizeC() + "'.");
+                    + "' greater than sizeC '" + getSizeC() + "' or < '0'.");
         }
 
         if (t != null && (t > getSizeT() - 1 || t < 0)) {

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
@@ -502,7 +503,7 @@ public class ZarrPixelBufferTest {
         }
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testTileIntegerOverflow()
             throws IOException, InvalidRangeException {
         int sizeT = 1;
@@ -534,9 +535,8 @@ public class ZarrPixelBufferTest {
         }
     }
 
-    @Test(expected = DimensionsOutOfBoundsException.class)
-    public void testTileExceedsMinMax()
-            throws IOException, InvalidRangeException {
+    @Test(expected = IllegalArgumentException.class)
+    public void testTileExceedsMinMax() throws IOException {
         int sizeT = 1;
         int sizeC = 3;
         int sizeZ = 1;

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
@@ -534,8 +534,9 @@ public class ZarrPixelBufferTest {
         }
     }
 
-    @Test
-    public void testTileExceedsMax() throws IOException, InvalidRangeException {
+    @Test(expected = DimensionsOutOfBoundsException.class)
+    public void testTileExceedsMinMax()
+            throws IOException, InvalidRangeException {
         int sizeT = 1;
         int sizeC = 3;
         int sizeZ = 1;
@@ -550,8 +551,9 @@ public class ZarrPixelBufferTest {
 
         try (ZarrPixelBuffer zpbuf =
                 createPixelBuffer(pixels, output.resolve("0"), 32, 32)) {
-            PixelData pixelData = zpbuf.getTile(0, 0, 0, 0, 0, 32, 33);
-            Assert.assertNull(pixelData);
+            Assert.assertNull(zpbuf.getTile(0, 0, 0, 0, 0, 32, 33));
+            // Throws exception
+            zpbuf.getTile(0, 0, 0, -1, 0, 1, 1);
         }
     }
 

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
 
 import org.junit.Assert;
@@ -530,8 +529,7 @@ public class ZarrPixelBufferTest {
         mapper.writeValue(output.resolve("0/0/.zarray").toFile(), zArray);
         try (ZarrPixelBuffer zpbuf =
                 createPixelBuffer(pixels, output.resolve("0"), 32, 32)) {
-            PixelData pixelData = zpbuf.getTile(0, 0, 0, 0, 0, 50000, 50000);
-            Assert.assertNull(pixelData);
+            zpbuf.getTile(0, 0, 0, 0, 0, 50000, 50000);
         }
     }
 

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
@@ -503,7 +503,7 @@ public class ZarrPixelBufferTest {
     }
 
     @Test
-    public void testIntegerOverflow()
+    public void testTileIntegerOverflow()
             throws IOException, InvalidRangeException {
         int sizeT = 1;
         int sizeC = 3;
@@ -517,6 +517,8 @@ public class ZarrPixelBufferTest {
                 sizeT, sizeC, sizeZ, sizeY, sizeX, "uint16",
                 resolutions);
 
+        // Hack the .zarray so we can appear as though we have more data than
+        // we actually have written above.
         ObjectMapper mapper = new ObjectMapper();
         HashMap<String, Object> zArray = mapper.readValue(
                 Files.readAllBytes(output.resolve("0/0/.zarray")),

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
@@ -45,8 +45,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 
 import picocli.CommandLine;
 import com.glencoesoftware.bioformats2raw.Converter;
-import com.glencoesoftware.omero.zarr.ZarrPixelsService;
-import com.glencoesoftware.omero.zarr.ZarrPixelBuffer;
 
 import loci.formats.FormatTools;
 import loci.formats.in.FakeReader;


### PR DESCRIPTION
Much more thorough range changes for tile retrieval. In particular this will prevent the allocation of intermediate large arrays during the tile caching phase of tile retrieval only for the resulting read to fail.

/cc @mabruce 