### PR TITLE
Handle Zarr data that is downsampled in Z

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java
@@ -831,9 +831,8 @@ public class ZarrPixelBuffer implements PixelBuffer {
             // if no Z downsampling, this is just an identity map
             int fullResZ = fullResolutionArray.getShape()[2];
             int arrayZ = array.getShape()[2];
-            int zStep = fullResZ / arrayZ;
             for (int z=0; z<fullResZ; z++) {
-                zIndexMap.put(z, z * zStep);
+                zIndexMap.put(z, Math.round(z * arrayZ / fullResZ));
             }
         } catch (Exception e) {
             // FIXME: Throw the right exception


### PR DESCRIPTION
As discussed with @chris-allan.

The test in 09670b0 writes a Zarr dataset that is downsampled in Z; this test should fail without the fix in ae60b7f.

I can add more tests if needed, but wanted to open this first to make sure I'm on the right track.