### PR TITLE
Upgrade tika-core to the latest 1.x release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation 'dev.zarr:jzarr:0.4.2'
     implementation 'org.lasersonlab:s3fs:2.2.3'
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.659'
+    implementation 'org.apache.tika:tika-core:1.28.5'
 
     testImplementation 'info.picocli:picocli:4.7.5'
     testImplementation 'com.glencoesoftware:bioformats2raw:0.9.1'


### PR DESCRIPTION
See https://tika.apache.org/ and https://github.com/apache/tika/blob/1.28.5/CHANGES.txt for the list of underlying changes including a few CVEs.

The `tika-core` libary is only used in the `com.upplication.s3fs.S3SeekableByteChannel#sync` and `com.upplication.s3fs3.S3FileChannel#seek` methods of the upstream `s3fs` dependencies. Both methods are called when syncing temporary files to a remote S3 path.
In the context of the OME-Zarr pixel buffer, S3 access is treated as read-only.  In f7f7818 we introduced our own subclasses of `java.nio.channels.FileChannel` and `java.nio.channels.SeekableByteChannel` with some performance optimizations, see https://www.glencoesoftware.com/blog/2024/04/15/optimizations-ome-zarr.html, so the upgrade of `tika-core` should have no noticeable impact on the workflow.

Testing should be focused on OME-Zarr (images & labels) hosted on AWS S3 and confirm the different workflows (import, reading) are all  working as expeced