### PR TITLE
Connect using endpoint and anonymous option

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -36,6 +36,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.upplication.s3fs.AmazonS3ClientFactory;
 
+import Ice.SysLoggerI;
+
 public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
 
 
@@ -132,15 +134,12 @@ public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
      */
     private String getEndPointFromUri(URI uri) {
         String host = uri.getHost();
-        if (host.contains("amazonaws.com")) {
-            return ENDPOINT;
-        }
-        // Check if is an endpoint other than s3.amazonaws.com
+        // Check if is an endpoint is specified
         String[] values = host.split("\\.");
-        if (values.length > 1) {
-            return "https://" + host;
+        if (values.length == 1) {
+            throw new RuntimeException("Endpoint " + host + " not supported");
         }
-        return ENDPOINT;
+        return "https://" + host;
     }
 
     @Override

--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -79,7 +79,7 @@ public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
             anonymous = ANONYMOUS_PROFILE.equals(keyID) && ANONYMOUS_PROFILE.equals(secretKey);
 
         } catch (Exception e) {
-            log.error("Failed to create credentials provider for anonymous profile", e);
+            log.debug("Failed to create credentials provider for anonymous profile", e);
         }
         if (anonymous) {
             log.debug("Using anonymous credentials");

--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -39,8 +39,14 @@ import com.upplication.s3fs.AmazonS3ClientFactory;
 public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
 
 
+    /**
+     * Default end point
+     */
     public static final String ENDPOINT = "https://s3.amazonaws.com";
 
+    /**
+     * See https://github.com/lasersonlab/Amazon-S3-FileSystem-NIO2
+     */
     public static final String ANONYMOUS_PROFILE = "s3fs_anonymous";
 
     private static final org.slf4j.Logger log =
@@ -73,7 +79,6 @@ public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
         } catch (Exception e) {
             log.error("Failed to create credentials provider for anonymous profile", e);
         }
-        System.out.println("Anonymous: " + anonymous);
         if (anonymous) {
             log.debug("Using anonymous credentials");
             return new AWSStaticCredentialsProvider(

--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -36,7 +36,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.upplication.s3fs.AmazonS3ClientFactory;
 
-import Ice.SysLoggerI;
 
 public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
 

--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelsService.java
@@ -173,10 +173,6 @@ public class ZarrPixelsService extends ome.io.nio.PixelsService {
                 if (profile != null) {
                     env.put("s3fs_credential_profile_name", profile);
                 }
-                String anonymous =
-                        Optional.ofNullable(params.get("anonymous"))
-                                .orElse("false");
-                env.put("s3fs_anonymous", anonymous);
                 OmeroS3FilesystemProvider fsp = new OmeroS3FilesystemProvider();
                 FileSystem fs = fsp.newFileSystem(uri, env);
                 return fs.getPath(bucket, rest);


### PR DESCRIPTION
* Use the endpoint to connect. The code currently uses following format ``s3://[endpoint]/[bucket]/[key]``. The proposed change no longer assumes that the ``[endpoint]`` has the region information but it still assumes that the endpoint is provided
* Do not use the url to indicate to use an anonymous connection. The changes have been tested on merge-ci
using data from ``s3://s3.us-west-2.amazonaws.com/cellpainting-gallery`` and ``s3://uk1s3.embassy.ebi.ac.uk/idr``
configuration in ``.aws/credentials``

The anonymous connection should be specified by adding a profile in ``.aws/credentials``
as follows
```
[s3fs_anonymous]
aws_access_key_id = s3fs_anonymous
aws_secret_access_key = s3fs_anonymous
```

This approach was chosen so we could introduce new profile depending on endpoint if required. Key and secret cannot be left empty
