### PR TITLE
Endpoint support

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/OmeroAmazonS3ClientFactory.java
@@ -106,14 +106,8 @@ public class OmeroAmazonS3ClientFactory extends AmazonS3ClientFactory {
      * @param uri The URI to handle
      * @return The endpoint
      */
-    private String getEndPointFromUri(URI uri) {
-        String host = uri.getHost();
-        // Check if is an endpoint is specified
-        String[] values = host.split("\\.");
-        if (values.length == 1) {
-            throw new RuntimeException("Endpoint " + host + " not supported");
-        }
-        return "https://" + host;
+    public String getEndPointFromUri(URI uri) {
+        return "https://" + uri.getHost();
     }
 
     @Override


### PR DESCRIPTION
This PR replaces the original work done in https://github.com/glencoesoftware/omero-zarr-pixel-buffer/pull/24

Use the endpoint to connect. The code currently uses following format s3://[endpoint]/[bucket]/[key]. The proposed change no longer assumes that the [endpoint] has the region information but it still assumes that the endpoint is provided