### PR TITLE
Add clarification about the downsampling factor expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Zarr multiscales group must be conformant with the default layout generated 
 -    the version of the NGFF specification must be 0.4
 -    the image and the Zarr multiscales group must have 5 declared dimensions
 -    the chunks must be stored in the (t, c, z, y, x) order
--    the resolution level must be downsampled along the (y, x) axis
+-    the resolution levels must be downsampled along the (y, x) axis by a factor 2
 
 For Zarr data hosted on AWS S3, requests must supply
 [credentials](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html).


### PR DESCRIPTION
Consistently with the current implementation in https://github.com/glencoesoftware/omero-zarr-pixel-buffer/blob/7b25b245f0dd46ea24620fee38ec471e330d9afd/src/main/java/com/glencoesoftware/omero/zarr/ZarrPixelBuffer.java#L854-L872, this updates the README to document the current expectation that resolution must be downsampled by a factor 2 alongside X and Y

Note this constraint might be up for discussion especially as recent work in #28 allows to read the scaling factor from the metadata but this would need to be captured and discussed in a dedicated issue.