### PR TITLE
Handle ? properly

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
@@ -65,6 +65,10 @@ public class ZarrStore {
 
     private static final org.slf4j.Logger log = LoggerFactory.getLogger(ZarrStore.class);
 
+    private static final String QUERY_REGEX = "\\?.+=.+";
+
+    private static final String PATH_WITH_QUERY_REGEX = ".*" + QUERY_REGEX;
+
     /** The underlying store handle for accessing Zarr data. */
     StoreHandle store;
 
@@ -136,11 +140,11 @@ public class ZarrStore {
             final String[] rest = Arrays.copyOfRange(tmp, 2, tmp.length);
             // Remove all query parameters
             String rawFinalPart = rest[rest.length - 1];
-            rest[rest.length - 1] = rawFinalPart.replaceAll("\\?.+=.+", "");
+            rest[rest.length - 1] = removeQuery(rawFinalPart);
             this.name = String.join("/", rest);
             // Extract URL parameters for authentication
             Map<String, String> params = new HashMap<>();
-            if (rawFinalPart.matches(".*\\?.+=.+")) {
+            if (containsQueryString(rawFinalPart)) {
                 String query = rawFinalPart.substring(rawFinalPart.lastIndexOf("?") + 1);
                 if (query != null) {
                     String[] pairs = query.split("&");
@@ -194,6 +198,28 @@ public class ZarrStore {
         } else if (group instanceof dev.zarr.zarrjava.v3.Group) {
             zarrVersion = "3";
         }
+    }
+
+    /**
+     * A method to remove a query-parameter-like segment from a string.
+     *
+     * @param path The String to remove the parameter from
+     * @return The String without the query parameter segment if found
+     *         otherwise return path
+     */
+    public static String removeQuery(String path) {
+        return path.replaceAll(QUERY_REGEX, "");
+    }
+
+    /**
+     * A method which returns true if the provided string contains a query segment
+     * (i.e. matches the regular expression), otherwise returns false.
+     *
+     * @param path The String to check
+     * @return True if path contains a query segment, otherwise false
+     */
+    public static Boolean containsQueryString(String path) {
+        return path.matches(PATH_WITH_QUERY_REGEX);
     }
 
     private void assertNoAwsSystemEnvCredentials() {

--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
@@ -130,23 +130,18 @@ public class ZarrStore {
             store = new HttpStore(storePath).resolve(rest);
             iface = HttpStore.class;
         } else if (path.startsWith("s3")) {
-            // Remove all query parameters
-            String afterZarrExtn = path.substring(zarrIndex + 5);
-            String afterZarrExtnNoQueries = afterZarrExtn.replaceAll("\\?.+=.+", "");
-            String[] tmp = (pathToZarr + afterZarrExtnNoQueries)
-                    .replaceFirst("s3://", "").split("/");
+            String[] tmp = path.replaceFirst("s3://", "").split("/");
             final String host = tmp[0];
             final String bucket = tmp[1];
             final String[] rest = Arrays.copyOfRange(tmp, 2, tmp.length);
+            // Remove all query parameters
+            String rawFinalPart = rest[rest.length - 1];
+            rest[rest.length - 1] = rawFinalPart.replaceAll("\\?.+=.+", "");
             this.name = String.join("/", rest);
             // Extract URL parameters for authentication
             Map<String, String> params = new HashMap<>();
-            // TODO: Is there a better way for parsing query parameters
-            // in the presence of URL unsafe characters?
-            String[] afterZarrSplit = afterZarrExtn.split("/");
-            String finalPart = afterZarrSplit[afterZarrSplit.length - 1];
-            if (finalPart.matches(".*\\?.+=.+")) {
-                String query = finalPart.substring(finalPart.lastIndexOf("?") + 1);
+            if (rawFinalPart.matches(".*\\?.+=.+")) {
+                String query = rawFinalPart.substring(rawFinalPart.lastIndexOf("?") + 1);
                 if (query != null) {
                     String[] pairs = query.split("&");
                     for (String pair : pairs) {

--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
@@ -121,35 +121,41 @@ public class ZarrStore {
             int sep = path.lastIndexOf("/");
             String storePath = path.substring(0, sep);
             String rest = path.substring(sep + 1);
+            // TODO: Fix names with "?" characters
             this.name = path.substring(pathToZarr.lastIndexOf("/") + 1);
             if (this.name.contains("?")) {
                 this.name = this.name.substring(0, this.name.indexOf("?"));
             }
+
             store = new HttpStore(storePath).resolve(rest);
             iface = HttpStore.class;
         } else if (path.startsWith("s3")) {
-            String[] tmp = path.replaceFirst("s3://", "").replaceAll("\\?.+", "").split("/");
+            // Remove all query parameters
+            String afterZarrExtn = path.substring(zarrIndex + 5);
+            String afterZarrExtnNoQueries = afterZarrExtn.replaceAll("\\?.+=.+", "");
+            String[] tmp = (pathToZarr + afterZarrExtnNoQueries)
+                    .replaceFirst("s3://", "").split("/");
             final String host = tmp[0];
             final String bucket = tmp[1];
             final String[] rest = Arrays.copyOfRange(tmp, 2, tmp.length);
-            this.name = path.substring(pathToZarr.lastIndexOf("/") + 1);
-            if (this.name.contains("?")) {
-                this.name = this.name.substring(0, this.name.indexOf("?"));
-            }
+            this.name = String.join("/", rest);
             // Extract URL parameters for authentication
             Map<String, String> params = new HashMap<>();
             // TODO: Is there a better way for parsing query parameters
             // in the presence of URL unsafe characters?
-            String query = orgPath.substring(orgPath.lastIndexOf("?") + 1);
-            if (query != null) {
-                String[] pairs = query.split("&");
-                for (String pair : pairs) {
-                    int idx = pair.indexOf("=");
-                    if (idx > 0) {
-                        params.put(pair.substring(0, idx), pair.substring(idx + 1));
+            String[] afterZarrSplit = afterZarrExtn.split("/");
+            String finalPart = afterZarrSplit[afterZarrSplit.length - 1];
+            if (finalPart.matches(".*\\?.+=.+")) {
+                String query = finalPart.substring(finalPart.lastIndexOf("?") + 1);
+                if (query != null) {
+                    String[] pairs = query.split("&");
+                    for (String pair : pairs) {
+                        int idx = pair.indexOf("=");
+                        if (idx > 0) {
+                            params.put(pair.substring(0, idx), pair.substring(idx + 1));
+                        }
                     }
                 }
-
             }
 
             URI endpoint = new URI("https://" + host);

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrPixelBufferTest.java
@@ -88,30 +88,6 @@ public class ZarrPixelBufferTest {
         test(output.toString());
     }
 
-    @Test
-    public void testNGFF05HTTP() throws Exception {
-        System.out.println("Testing NGFF05HTTP");
-        test(NGFF05_HTTP);
-    }
-
-    @Test
-    public void testNGFF04HTTP() throws Exception {
-        System.out.println("Testing NGFF04HTTP");
-        test(NGFF04_HTTP);
-    }
-
-    @Test
-    public void testNGFF05S3Anon() throws Exception {
-        System.out.println("Testing testNGFF05S3Anon");
-        test(NGFF05_S3_ANON);
-    }
-
-    @Test
-    public void testNGFF04S3Anon() throws Exception {
-        System.out.println("Testing testNGFF04S3Anon");
-        test(NGFF04_S3_ANON);
-    }
-
     void test(String path) throws Exception {
         System.out.println("Testing path: " + path);
         ZarrStore store = new ZarrStore(path.toString());

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrStoreTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrStoreTest.java
@@ -1,0 +1,67 @@
+package com.glencoesoftware.omero.zarr;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Unit test for ZarrStore. */
+public class ZarrStoreTest {
+
+    @Test
+    public void testRemoveQuery() {
+        Assert.assertEquals("/my/test/path",
+            ZarrStore.removeQuery("/my/test/path?test=zarr.zarr"));
+
+        Assert.assertEquals("/my/test/path",
+            ZarrStore.removeQuery("/my/test/path?query=test1?query=test2"));
+
+        Assert.assertEquals("/my/test/path",
+                ZarrStore.removeQuery("/my/test/path?/more/path/stuff/query=test1"));
+
+        Assert.assertEquals("/my/test/path",
+                ZarrStore.removeQuery("/my/test/path?/more?/path?/stuff?/query=test1"));
+
+        Assert.assertEquals("/my/test/path/myfile.zarr",
+                ZarrStore.removeQuery("/my/test/path/myfile.zarr?anonymous=true"));
+
+        Assert.assertEquals("", ZarrStore.removeQuery("?query=test1"));
+    }
+
+    @Test
+    public void testRemoveNothing() {
+
+        Assert.assertEquals("", ZarrStore.removeQuery(""));
+
+        Assert.assertEquals("/my/test/path?test-zarr.zarr",
+                ZarrStore.removeQuery("/my/test/path?test-zarr.zarr"));
+
+        Assert.assertEquals("/my/test/path=test?zarr.zarr",
+                ZarrStore.removeQuery("/my/test/path=test?zarr.zarr"));
+
+        Assert.assertEquals("/my/test/path.zarr",
+                ZarrStore.removeQuery("/my/test/path.zarr"));
+    }
+
+    @Test
+    public void testMatch() {
+        Assert.assertTrue(ZarrStore.containsQueryString("?query=only"));
+        Assert.assertTrue(ZarrStore.containsQueryString("path?matches=query"));
+        Assert.assertTrue(ZarrStore.containsQueryString("my/zarr/path.zarr?matches=query"));
+        Assert.assertTrue(ZarrStore.containsQueryString(
+                "my/zarr/path.zarr/?te/st?1/23?matches=query=test"));
+        Assert.assertTrue(ZarrStore.containsQueryString(
+                "   my/zarr/path with spaces.zarr?  weird = query   "));
+        Assert.assertTrue(ZarrStore.containsQueryString(" ? = "));
+    }
+
+    @Test
+    public void testNoMatch() {
+        Assert.assertFalse(ZarrStore.containsQueryString(""));
+        Assert.assertFalse(ZarrStore.containsQueryString("?="));
+        Assert.assertFalse(ZarrStore.containsQueryString("?=afteronly"));
+        Assert.assertFalse(ZarrStore.containsQueryString("beforeonly?="));
+        Assert.assertFalse(ZarrStore.containsQueryString("?middleonly="));
+        Assert.assertFalse(ZarrStore.containsQueryString("my/zarr/path.zarr"));
+        Assert.assertFalse(ZarrStore.containsQueryString("my/zarr/path=test?zarr"));
+    }
+
+}


### PR DESCRIPTION
Previously, the code did not handle the "?" character properly in S3 paths. It was assumed that the presence of a "?" indicated a query parameter and so anything after a "?" was removed. However, "?" is a legal character in S3 object names and so should be supported. This meant that attempting to read a file at `s3://bucket/key/zarrv3/test?file.zarr` would result in an error like
```
dev.zarr.zarrjava.ZarrException: No Zarr group found at s3://bucket/key/zarrv3/test;
	at dev.zarr.zarrjava.core.Group.open(Group.java:38)

```

With this PR, "?" characters should be fully supported in S3 zarr paths with the following exception: If a path contains a query-string-like section in the last segment of the path, the code will attempt to read it as a query parameter which will cause an error. e.g. `s3://my-bucket/path/to/my?zarr=test.zarr` will fail.