### PR TITLE
Fix query handling for anonymous and profile

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
@@ -202,13 +202,23 @@ public class ZarrStore {
 
     /**
      * A method to remove a query-parameter-like segment from a string.
+     * this method assumes there will be no ? characters in the parameters.
+     * This means the method will only search from the last instance of the "?"
+     * character until the end of the string.
      *
      * @param path The String to remove the parameter from
      * @return The String without the query parameter segment if found
      *         otherwise return path
      */
     public static String removeQuery(String path) {
-        return path.replaceAll(QUERY_REGEX, "");
+        int lastQuestionMarkIdx = path.lastIndexOf("?");
+        if (lastQuestionMarkIdx != -1) {
+            String potentialQuery = path.substring(lastQuestionMarkIdx);
+            if (potentialQuery.matches(QUERY_REGEX)) {
+                return path.substring(0, lastQuestionMarkIdx);
+            }
+        }
+        return path;
     }
 
     /**

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrStoreTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrStoreTest.java
@@ -11,17 +11,26 @@ public class ZarrStoreTest {
         Assert.assertEquals("/my/test/path",
             ZarrStore.removeQuery("/my/test/path?test=zarr.zarr"));
 
-        Assert.assertEquals("/my/test/path",
+        Assert.assertEquals("/my/test/path?query=test1",
             ZarrStore.removeQuery("/my/test/path?query=test1?query=test2"));
 
         Assert.assertEquals("/my/test/path",
                 ZarrStore.removeQuery("/my/test/path?/more/path/stuff/query=test1"));
 
-        Assert.assertEquals("/my/test/path",
+        Assert.assertEquals("/my/test/path?/more?/path?/stuff",
                 ZarrStore.removeQuery("/my/test/path?/more?/path?/stuff?/query=test1"));
 
         Assert.assertEquals("/my/test/path/myfile.zarr",
                 ZarrStore.removeQuery("/my/test/path/myfile.zarr?anonymous=true"));
+
+        Assert.assertEquals("/my/test/path/myfile=?withquestionmark.zarr",
+                ZarrStore.removeQuery(
+                        "/my/test/path/myfile=?withquestionmark.zarr?anonymous=true"));
+
+
+        Assert.assertEquals("/my/test/path/myfile=?withquestionmark.zarr",
+                ZarrStore.removeQuery(
+                        "/my/test/path/myfile=?withquestionmark.zarr?profile=test= name"));
 
         Assert.assertEquals("", ZarrStore.removeQuery("?query=test1"));
     }


### PR DESCRIPTION
Completes the work from #46 

Prior to #46, any S3 URI with a "?" character would fail. With #46, they would succeed, but only for instance profile or default profile credentials, i.e. only if there wasn't an added credentials query string. If there was, the regex would match from the first question mark (in the last part of the URI) all the way to the end of the URI, removing part of the file path along with the query string. e.g. `s3://bucket/path/to/my?test.zarr?anonymous=true` would be reduced to `s3://bucket/path/to/my`, since `?test.zarr?anonymous=true` matches the regex. 

With this PR, we are more conservative with removal. We leverage the fact that AWS profile names do not allow for "?" characters, and so if there is a query string, it should begin with the very last "?" in the URI. We test only that portion of the URI against the regex and remove it if it is a match. So with this PR, the above example would be `s3://bucket/path/to/my?test.zarr`.

Unit tests were added to test this behavior.