### PR TITLE
Consolidate and improve the utility of the query utility functions

### DIFF
--- a/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
+++ b/src/main/java/com/glencoesoftware/omero/zarr/ZarrStore.java
@@ -140,19 +140,21 @@ public class ZarrStore {
             final String[] rest = Arrays.copyOfRange(tmp, 2, tmp.length);
             // Remove all query parameters
             String rawFinalPart = rest[rest.length - 1];
-            rest[rest.length - 1] = removeQuery(rawFinalPart);
+            String[] pathAndQuery = splitOnQuery(rawFinalPart);
+            rest[rest.length - 1] = pathAndQuery[0];
             this.name = String.join("/", rest);
             // Extract URL parameters for authentication
             Map<String, String> params = new HashMap<>();
-            if (containsQueryString(rawFinalPart)) {
-                String query = rawFinalPart.substring(rawFinalPart.lastIndexOf("?") + 1);
-                if (query != null) {
-                    String[] pairs = query.split("&");
-                    for (String pair : pairs) {
-                        int idx = pair.indexOf("=");
-                        if (idx > 0) {
-                            params.put(pair.substring(0, idx), pair.substring(idx + 1));
-                        }
+            String query = pathAndQuery[1];
+            if (query != null) {
+                if (query.startsWith("?")) {
+                    query = query.substring(1);
+                }
+                String[] pairs = query.split("&");
+                for (String pair : pairs) {
+                    int idx = pair.indexOf("=");
+                    if (idx > 0) {
+                        params.put(pair.substring(0, idx), pair.substring(idx + 1));
                     }
                 }
             }
@@ -201,35 +203,28 @@ public class ZarrStore {
     }
 
     /**
-     * A method to remove a query-parameter-like segment from a string.
+     * A method to split a query-parameter-like segment from a string.
      * this method assumes there will be no ? characters in the parameters.
      * This means the method will only search from the last instance of the "?"
      * character until the end of the string.
      *
-     * @param path The String to remove the parameter from
-     * @return The String without the query parameter segment if found
-     *         otherwise return path
+     * @param uri The String to remove the parameter from
+     * @return A String array of size 2. First element is the path without the query
+     *         (or entire path if no query is found) and the second is the query string
+     *         or {@code null} if no query is found.
      */
-    public static String removeQuery(String path) {
-        int lastQuestionMarkIdx = path.lastIndexOf("?");
+    public static String[] splitOnQuery(String uri) {
+        String[] pathAndQuery = new String[2];
+        pathAndQuery[0] = uri;
+        int lastQuestionMarkIdx = uri.lastIndexOf("?");
         if (lastQuestionMarkIdx != -1) {
-            String potentialQuery = path.substring(lastQuestionMarkIdx);
+            String potentialQuery = uri.substring(lastQuestionMarkIdx);
             if (potentialQuery.matches(QUERY_REGEX)) {
-                return path.substring(0, lastQuestionMarkIdx);
+                pathAndQuery[0] = uri.substring(0, lastQuestionMarkIdx);
+                pathAndQuery[1] = potentialQuery;
             }
         }
-        return path;
-    }
-
-    /**
-     * A method which returns true if the provided string contains a query segment
-     * (i.e. matches the regular expression), otherwise returns false.
-     *
-     * @param path The String to check
-     * @return True if path contains a query segment, otherwise false
-     */
-    public static Boolean containsQueryString(String path) {
-        return path.matches(PATH_WITH_QUERY_REGEX);
+        return pathAndQuery;
     }
 
     private void assertNoAwsSystemEnvCredentials() {

--- a/src/test/java/com/glencoesoftware/omero/zarr/ZarrStoreTest.java
+++ b/src/test/java/com/glencoesoftware/omero/zarr/ZarrStoreTest.java
@@ -7,70 +7,63 @@ import org.junit.Test;
 public class ZarrStoreTest {
 
     @Test
-    public void testRemoveQuery() {
-        Assert.assertEquals("/my/test/path",
-            ZarrStore.removeQuery("/my/test/path?test=zarr.zarr"));
+    public void testSplitOnQuery() {
+        String[] pathAndQuery = ZarrStore.splitOnQuery("/my/test/path?test=zarr.zarr");
+        Assert.assertEquals("/my/test/path", pathAndQuery[0]);
+        Assert.assertEquals("?test=zarr.zarr", pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path?query=test1",
-            ZarrStore.removeQuery("/my/test/path?query=test1?query=test2"));
+        pathAndQuery = ZarrStore.splitOnQuery("/my/test/path?query=test1?query=test2");
+        Assert.assertEquals("/my/test/path?query=test1", pathAndQuery[0]);
+        Assert.assertEquals("?query=test2", pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path",
-                ZarrStore.removeQuery("/my/test/path?/more/path/stuff/query=test1"));
+        pathAndQuery = ZarrStore.splitOnQuery("/my/test/path?/more/path/stuff/query=test1");
+        Assert.assertEquals("/my/test/path", pathAndQuery[0]);
+        Assert.assertEquals("?/more/path/stuff/query=test1", pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path?/more?/path?/stuff",
-                ZarrStore.removeQuery("/my/test/path?/more?/path?/stuff?/query=test1"));
+        pathAndQuery = ZarrStore.splitOnQuery("/my/test/path/myfile.zarr?anonymous=true");
+        Assert.assertEquals("/my/test/path/myfile.zarr", pathAndQuery[0]);
+        Assert.assertEquals("?anonymous=true", pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path/myfile.zarr",
-                ZarrStore.removeQuery("/my/test/path/myfile.zarr?anonymous=true"));
+        pathAndQuery = ZarrStore.splitOnQuery(
+                "/my/test/path/myfile=?withquestionmark.zarr?anonymous=true");
+        Assert.assertEquals("/my/test/path/myfile=?withquestionmark.zarr", pathAndQuery[0]);
+        Assert.assertEquals("?anonymous=true", pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path/myfile=?withquestionmark.zarr",
-                ZarrStore.removeQuery(
-                        "/my/test/path/myfile=?withquestionmark.zarr?anonymous=true"));
+        pathAndQuery = ZarrStore.splitOnQuery(
+                "/my/test/path/myfile=?withquestionmark.zarr?profile=test= name");
+        Assert.assertEquals("/my/test/path/myfile=?withquestionmark.zarr", pathAndQuery[0]);
+        Assert.assertEquals("?profile=test= name", pathAndQuery[1]);
 
-
-        Assert.assertEquals("/my/test/path/myfile=?withquestionmark.zarr",
-                ZarrStore.removeQuery(
-                        "/my/test/path/myfile=?withquestionmark.zarr?profile=test= name"));
-
-        Assert.assertEquals("", ZarrStore.removeQuery("?query=test1"));
+        pathAndQuery = ZarrStore.splitOnQuery("?query=test1");
+        Assert.assertEquals("", pathAndQuery[0]);
+        Assert.assertEquals("?query=test1", pathAndQuery[1]);
     }
 
     @Test
     public void testRemoveNothing() {
 
-        Assert.assertEquals("", ZarrStore.removeQuery(""));
+        String[] pathAndQuery = ZarrStore.splitOnQuery("");
+        Assert.assertEquals("", pathAndQuery[0]);
+        Assert.assertNull(pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path?test-zarr.zarr",
-                ZarrStore.removeQuery("/my/test/path?test-zarr.zarr"));
+        pathAndQuery = ZarrStore.splitOnQuery("/my/test/path?test-zarr.zarr");
+        Assert.assertEquals("/my/test/path?test-zarr.zarr", pathAndQuery[0]);
+        Assert.assertNull(pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path=test?zarr.zarr",
-                ZarrStore.removeQuery("/my/test/path=test?zarr.zarr"));
+        pathAndQuery = ZarrStore.splitOnQuery("/my/test/path=test?zarr.zarr");
+        Assert.assertEquals("/my/test/path=test?zarr.zarr", pathAndQuery[0]);
+        Assert.assertNull(pathAndQuery[1]);
 
-        Assert.assertEquals("/my/test/path.zarr",
-                ZarrStore.removeQuery("/my/test/path.zarr"));
+        pathAndQuery = ZarrStore.splitOnQuery("nothing/in/the/middle?=test");
+        Assert.assertEquals("nothing/in/the/middle?=test", pathAndQuery[0]);
+        Assert.assertNull(pathAndQuery[1]);
+
+        pathAndQuery = ZarrStore.splitOnQuery("nothing/at/the/end?=");
+        Assert.assertEquals("nothing/at/the/end?=", pathAndQuery[0]);
+        Assert.assertNull(pathAndQuery[1]);
+
+        pathAndQuery = ZarrStore.splitOnQuery("/my/test/path.zarr");
+        Assert.assertEquals("/my/test/path.zarr", pathAndQuery[0]);
+        Assert.assertNull(pathAndQuery[1]);
     }
-
-    @Test
-    public void testMatch() {
-        Assert.assertTrue(ZarrStore.containsQueryString("?query=only"));
-        Assert.assertTrue(ZarrStore.containsQueryString("path?matches=query"));
-        Assert.assertTrue(ZarrStore.containsQueryString("my/zarr/path.zarr?matches=query"));
-        Assert.assertTrue(ZarrStore.containsQueryString(
-                "my/zarr/path.zarr/?te/st?1/23?matches=query=test"));
-        Assert.assertTrue(ZarrStore.containsQueryString(
-                "   my/zarr/path with spaces.zarr?  weird = query   "));
-        Assert.assertTrue(ZarrStore.containsQueryString(" ? = "));
-    }
-
-    @Test
-    public void testNoMatch() {
-        Assert.assertFalse(ZarrStore.containsQueryString(""));
-        Assert.assertFalse(ZarrStore.containsQueryString("?="));
-        Assert.assertFalse(ZarrStore.containsQueryString("?=afteronly"));
-        Assert.assertFalse(ZarrStore.containsQueryString("beforeonly?="));
-        Assert.assertFalse(ZarrStore.containsQueryString("?middleonly="));
-        Assert.assertFalse(ZarrStore.containsQueryString("my/zarr/path.zarr"));
-        Assert.assertFalse(ZarrStore.containsQueryString("my/zarr/path=test?zarr"));
-    }
-
 }


### PR DESCRIPTION
Currently, we have two functions which perform similar tasks: `removeQuery` and `containsQueryString`. Both of these attempt to do similar things, but do them very slightly differently, which is an issue. Also, neither of them provides the useful feature of actually returning the query portion of the input `String`. This means that if you want the query portion you have to determine that  the input string matches the pattern and then do manual substring extraction. This duplicates logic which is already performed in `removeQuery` to identify the portion of the string _before_ the query. 

With this PR, both `removeQuery` and `containsQueryString` are removed. Instead they are replaced with `splitOnQuery`, which takes an input string and returns a `String` array of size 2 where the first value is the portion of the string before the query (or the entire string if there is no query), and the second value is the query string (or null if there is no query string). This allows for a single call to perform the logic of detecting the presence of a query string, providing the string without the query, and providing the query without the rest of the string. Since it is a `public static` function, this means this logic can be easily used by clients to ensure consistent detection of query strings. 

Behavior should not change at all with this PR, but tests have been updated and added to use the new function.