### PR TITLE
Bump dev.zarr:zarr-java to version 0.2.0 with sharding fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 dependencies {
     api 'org.openmicroscopy:omero-blitz:5.8.4'
 
-    implementation "dev.zarr:zarr-java:0.1.3"
+    implementation "dev.zarr:zarr-java:0.2.0"
 
     implementation "ome:formats-api:8.5.0"
     implementation "software.amazon.awssdk:aws-core:2.34.6"

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    api 'org.openmicroscopy:omero-blitz:5.8.4'
+    api 'org.openmicroscopy:omero-blitz:5.8.5'
 
     implementation "dev.zarr:zarr-java:0.2.0"
 


### PR DESCRIPTION
This includes the fix for https://github.com/zarr-developers/zarr-java/issues/79 allowing the pixel buffer to read sharded OME-Zarr 0.5 datasets from object storage
Also bumps org.openmicroscopy:omero-blitz to version 5.8.5

Fixes https://github.com/glencoesoftware/omero-zarr-pixel-buffer/issues/47 as this should be the last code change before cutting a new release candidate of `omero-zarr-pixel-buffer` with Zarr v3 support
